### PR TITLE
Added option to set data on custom JIRA fields from the json send to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,29 @@ Building container:
 Running container:
 
     docker pull miel/exception-submitter-for-jira
-    docker run -d -p 3000:3000 -e "JIRA_URL=<url>" -e "JIRA_USER=<user>" -e "JIRA_PASSWD=<passwd>" --name exception-submitter miel/exception-submitter-for-jira
+    docker run -d -p 3000:3000 -e "JIRA_URL=<url>" \ 
+                               -e "JIRA_USER=<user>" \ 
+                               -e "JIRA_PASSWD=<passwd>" \ 
+                               -e "CUSTOM_FIELD_MAPPINGS={"customfield_123456": "myJsonFieldName", "customfield_654321": "myOtherJsonFieldName"}" \ 
+                               --name exception-submitter miel/exception-submitter-for-jira
+
+### Custom field mappings
+The 'CUSTOM_FIELD_MAPPINGS' are optional. They provide a way to map data field names to custon JIRA fields. 
+With the data field names the data wil be extracted from the json and assigned to the custom JIRA fields.
+This works currently only for fields at the root of the json, thus not for nested ones.
+
+There are two ways to provide custom mappings:
+  - Via config.ini file
+
+
+    [CUSTOM_FIELD_MAPPINGS]
+    customfield_123456: myJsonFieldName 
+    customfield_654321: myOtherJsonFieldName 
+
+  - Via environment variable as JSON
+
+
+    CUSTOM_FIELD_MAPPINGS={"customfield_123456": "myJsonFieldName", "customfield_654321": "myOtherJsonFieldName"}  
 
 ## Docker Repo
 Automatic builds: [https://hub.docker.com/r/miel/exception-submitter-for-jira/](https://hub.docker.com/r/miel/exception-submitter-for-jira/)

--- a/exceptionservice/config.py
+++ b/exceptionservice/config.py
@@ -1,6 +1,7 @@
 import configparser
 import logging
 import os
+import json
 
 __author__ = 'Miel Donkers <miel.donkers@gmail.com>'
 
@@ -33,3 +34,26 @@ if JIRA_PROJECT is None:
 
 if JIRA_ISSUE_TITLE is None:
     JIRA_ISSUE_TITLE = 'Exception'
+
+
+def create_custom_field_mappings():
+    """
+        CUSTOM_FIELD_MAPPINGS maps a custom field id from JIRA to a data field name.
+        * It can be configured at the config file under section [CUSTOM_FIELD_MAPPINGS]
+            For example: customfield_123456: myJsonFieldName
+        * Or as environment variable 'CUSTOM_FIELD_MAPPINGS' as json data
+            For example: {"customfield_123456": "myJsonFieldName", "customfield_654321": "myOtherJsonFieldName"}
+        This method converts them to a dictionary to be used later to assign the data to the custom field(s)
+    """
+    if config.has_section('CUSTOM_FIELD_MAPPINGS'):
+        options = config.options('CUSTOM_FIELD_MAPPINGS')
+        custom_field_mappings = {}
+        for option in options:
+            custom_field_mappings[option] = config.get('CUSTOM_FIELD_MAPPINGS', option)
+
+        return custom_field_mappings
+    else:
+        return json.loads(os.getenv('CUSTOM_FIELD_MAPPINGS', "{}"))
+
+
+CUSTOM_FIELD_MAPPINGS = create_custom_field_mappings()


### PR DESCRIPTION
The change add an optional configuration to set data on custom JIRA fields. 
The configuration implies a mapping of the custom field id to the name of the data field at the received JSON. 
Currently the data field is expected at the root of the JSON, so no nested data structures are supported right now. The data is also supposed to be simple data fields as strings or numbers.

The server extracts the data from the JSON an assigns this to the custom field id and does this for all configured custom fields. The custom JIRA fields are added to the "fields" part of the JSON structure send to JIRA.
The custom fields are filtered from the data show at the description of the JIRA issue.